### PR TITLE
Added summary and description so rubygems doesn't generate warnings

### DIFF
--- a/dropbox-api.gemspec
+++ b/dropbox-api.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |s|
   s.authors     = ["Marcin Bunsch"]
   s.email       = ["marcin@futuresimple.com"]
   s.homepage    = ""
-  s.summary     = %q{TODO: Write a gem summary}
-  s.description = %q{TODO: Write a gem description}
+  s.summary     = "A Ruby client for the DropBox REST API."
+  s.description = "To deliver a more Rubyesque experience when using the DropBox API."
 
   s.rubyforge_project = "dropbox-api"
 


### PR DESCRIPTION
Added summary and description so rubygems doesn't generate warnings.
`
Using dropbox-api (0.0.1) from git://github.com/futuresimple/dropbox-api.git (at master)
dropbox-api at /tmp/***/vendor/bundle/ruby/1.9.1/bundler/gems/dropbox-api-87b873541ce5 did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
"FIXME" or "TODO" is not a description
`
