### PR TITLE
use multi_json instead of insisting upon yajl

### DIFF
--- a/dropbox-api.gemspec
+++ b/dropbox-api.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "dropbox-api"
 
-  s.add_dependency 'yajl-ruby'
+  s.add_dependency 'multi_json'
   s.add_dependency 'oauth'
   s.add_dependency 'hashie'
 

--- a/lib/dropbox-api.rb
+++ b/lib/dropbox-api.rb
@@ -1,5 +1,5 @@
 require "oauth"
-require "yajl"
+require "multi_json"
 require "hashie"
 
 module Dropbox

--- a/lib/dropbox-api/connection/requests.rb
+++ b/lib/dropbox-api/connection/requests.rb
@@ -13,19 +13,19 @@ module Dropbox
             when 401
               raise Dropbox::API::Error::Unauthorized
             when 403
-              parsed = Yajl::Parser.parse(response.body)
+              parsed = MultiJson.decode(response.body)
               raise Dropbox::API::Error::Forbidden.new(parsed["error"])
             when 404
               raise Dropbox::API::Error::NotFound
             when 400, 406
-              parsed = Yajl::Parser.parse(response.body)
+              parsed = MultiJson.decode(response.body)
               raise Dropbox::API::Error.new(parsed["error"])
             when 300..399
               raise Dropbox::API::Error::Redirect
             when 500..599
               raise Dropbox::API::Error
             else
-              options[:raw] ? response.body : Yajl::Parser.parse(response.body)
+              options[:raw] ? response.body : MultiJson.decode(response.body)
           end
         end
 


### PR DESCRIPTION
I recommend switching to use [multi_json](https://github.com/intridea/multi_json) instead of YAJL. multi_json automatically uses the best available JSON parser, so it will still use YAJL if it is installed but will switch to something else if the user prefers. This is especially good in cases where it might not be possible to link in modules requiring native code.

The specs seems to be good after this change, except that `Dropbox::API::Client#download` is failing because there is no file called `test/test.txt` in my Dropbox. I couldn't find any code to create such a file, so I assume that I didn't cause this failure, but if I did then I'd love to know about it and will make the appropriate fixes.

Thanks!
