### PR TITLE
Better error classes

### DIFF
--- a/lib/dropbox-api/util/error.rb
+++ b/lib/dropbox-api/util/error.rb
@@ -1,14 +1,14 @@
 module Dropbox
   module API
 
-    class Error < Exception
+    class Error < StandardError
 
-      class ConnectionFailed < Exception; end
-      class Config < Exception; end
-      class Unauthorized < Exception; end
-      class Forbidden < Exception; end
-      class NotFound < Exception; end
-      class Redirect < Exception; end
+      class ConnectionFailed < Error; end
+      class Config < Error; end
+      class Unauthorized < Error; end
+      class Forbidden < Error; end
+      class NotFound < Error; end
+      class Redirect < Error; end
 
     end
 

--- a/spec/lib/dropbox-api/connection_spec.rb
+++ b/spec/lib/dropbox-api/connection_spec.rb
@@ -79,4 +79,22 @@ describe Dropbox::API::Connection do
     end
 
   end
+
+  describe "errors" do
+
+    it "recovers error with rescue statement modifier" do
+      expect { raise Dropbox::API::Error rescue nil }.to_not raise_error(Dropbox::API::Error)
+    end
+
+    it "recovers any kind of errors with the generic error" do
+      expect do
+        begin
+          raise Dropbox::API::Error::Forbidden
+        rescue Dropbox::API::Error
+        end
+      end.to_not raise_error
+    end
+
+  end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,8 +20,8 @@ Dir.glob("#{File.dirname(__FILE__)}/support/*.rb").each { |f| require f }
 # Clean up after specs, remove test-directory
 RSpec.configure do |config|
   config.after(:all) do
-    test_dir = Dropbox::Spec.instance.find(Dropbox::Spec.test_dir)
-    test_dir.destroy unless test_dir.is_deleted?
+    test_dir = Dropbox::Spec.instance.find(Dropbox::Spec.test_dir) rescue nil
+    test_dir.destroy if test_dir and !test_dir.is_deleted?
   end
 end
 


### PR DESCRIPTION
In this pull request,
- `Dropbox::API::Error` inherits `StandardError` rather than `Exception`
- `Dropbox::API::Error::*` inherits `Dropbox::API::Error`

That way, use code can be much simpler.
