### PR TITLE
Allow share_url and direct_url to be used on directories as well as files

### DIFF
--- a/lib/dropbox-api/objects/dir.rb
+++ b/lib/dropbox-api/objects/dir.rb
@@ -14,6 +14,11 @@ module Dropbox
         end
       end
 
+      def direct_url(options = {})
+        response = client.raw.shares({ :path => self.path, :short_url => false }.merge(options))
+        Dropbox::API::Object.init(response, client)
+      end
+
     end
 
   end

--- a/lib/dropbox-api/objects/file.rb
+++ b/lib/dropbox-api/objects/file.rb
@@ -28,6 +28,11 @@ module Dropbox
         client.download(self.path)
       end
 
+      def direct_url(options = {})
+        response = client.raw.media({ :path => self.path }.merge(options))
+        Dropbox::API::Object.init(response, client)
+      end
+
     end
 
   end

--- a/lib/dropbox-api/objects/fileops.rb
+++ b/lib/dropbox-api/objects/fileops.rb
@@ -27,11 +27,6 @@ module Dropbox
         Dropbox::API::Object.init(response, client)
       end
 
-      def direct_url(options = {})
-        response = client.raw.media({ :path => self.path }.merge(options))
-        Dropbox::API::Object.init(response, client)
-      end
-
     end
 
   end


### PR DESCRIPTION
Currently, the share_url and direct_url methods are a part of the File object, but these methods are also valid on Dir objects. Since the Fileops module is included by both, moving the methods there brings support for URLs to both types of objects.
