### PR TITLE
Use zendesk actions

### DIFF
--- a/.github/workflows/gempush.yml
+++ b/.github/workflows/gempush.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+    - uses: zendesk/checkout@v2
+    - name: Set up Ruby
+      uses: zendesk/setup-ruby@v1
       with:
-        version: 2.6.x
+        ruby-version: 2.6.x
 
     - name: Publish to RubyGems
       run: |

--- a/.github/workflows/gempush.yml
+++ b/.github/workflows/gempush.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Ruby
       uses: zendesk/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.6
 
     - name: Publish to RubyGems
       run: |


### PR DESCRIPTION
We have blocked 3rd party actions in zendesk org, which includes the github ones. We need to use our cloned actions inside zendesk org